### PR TITLE
add jbang catalog and docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,17 @@ curl https://repo1.maven.org/maven2/org/tomitribe/jamira/jamira-cli/0.1/jamira-c
 chmod 755 /usr/local/bin/jamira
 ----
 
+## Installation using JBang
+
+Jamira can be installed and run with jbang - it will even setup java for you if you do not have that available.
+
+---
+curl -Ls sh.jbang.dev | bash -s app install jamira@tomitribe/jamira
+jamira
+---
+
+## Completion 
+
 Additionally, if you want command completion you can add the following to your `~/.bash_profile`, `~/.bashrc` or similar environment setup scripts:
 
 ----

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,9 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "jamira": {
+      "script-ref": "org.tomitribe.jamira:jamira-cli:LATEST:shaded"
+    }
+  },
+  "templates": {}
+}


### PR DESCRIPTION
I spotted the shaded jar so made a jbang catalog that will pick up the LATEST (wether local snapshot or latest in maven repo).

You can change it to RELEASE if you want snapshots to be ignored, of set it to specific version number dependent on what you want 
`jbang jamira@tomitribe/jamira` to do.

btw. you can also instead put the alias in a repo called tomitribe/jbang-catalog and then it would just be `jbang jamira@tomitribe`