### PR TITLE
Adjust default SocketTimeOut to allow large bulk processing to complete

### DIFF
--- a/jamira-cli/src/main/java/org/tomitribe/jamira/cli/http/CustomAsynchronousHttpClientFactory.java
+++ b/jamira-cli/src/main/java/org/tomitribe/jamira/cli/http/CustomAsynchronousHttpClientFactory.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2021 Tomitribe and community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.jamira.cli.http;
+
+import com.atlassian.event.api.EventPublisher;
+import com.atlassian.httpclient.apache.httpcomponents.DefaultHttpClientFactory;
+import com.atlassian.httpclient.api.HttpClient;
+import com.atlassian.httpclient.api.factory.HttpClientOptions;
+import com.atlassian.jira.rest.client.api.AuthenticationHandler;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousHttpClientFactory;
+import com.atlassian.jira.rest.client.internal.async.AtlassianHttpClientDecorator;
+import com.atlassian.jira.rest.client.internal.async.DisposableHttpClient;
+import com.atlassian.sal.api.ApplicationProperties;
+import com.atlassian.sal.api.UrlMode;
+import com.atlassian.sal.api.executor.ThreadLocalContextManager;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.net.URI;
+import java.util.Date;
+
+/*
+ * Allows the specification of custom http client options.
+ */
+public class CustomAsynchronousHttpClientFactory extends AsynchronousHttpClientFactory {
+
+    @SuppressWarnings("unchecked")
+    public DisposableHttpClient createClient(final URI serverUri, final AuthenticationHandler authenticationHandler, final HttpClientOptions options) {
+        final DefaultHttpClientFactory defaultHttpClientFactory = new DefaultHttpClientFactory(
+                new EventPublisher() {
+                    @Override
+                    public void publish(Object o) {
+
+                    }
+
+                    @Override
+                    public void register(Object o) {
+
+                    }
+
+                    @Override
+                    public void unregister(Object o) {
+
+                    }
+
+                    @Override
+                    public void unregisterAll() {
+
+                    }
+                },
+                new CustomAsynchronousHttpClientFactory.RestClientApplicationProperties(serverUri),
+                new ThreadLocalContextManager() {
+                    @Override
+                    public Object getThreadLocalContext() {
+                        return null;
+                    }
+
+                    @Override
+                    public void setThreadLocalContext(Object context) {
+                    }
+
+                    @Override
+                    public void clearThreadLocalContext() {
+                    }
+                });
+
+        final HttpClient httpClient = defaultHttpClientFactory.create(options);
+
+        return new AtlassianHttpClientDecorator(httpClient, authenticationHandler) {
+            @Override
+            public void destroy() throws Exception {
+                defaultHttpClientFactory.dispose(httpClient);
+            }
+        };
+    }
+
+    private static class NoOpEventPublisher implements EventPublisher {
+        @Override
+        public void publish(Object o) {
+        }
+
+        @Override
+        public void register(Object o) {
+        }
+
+        @Override
+        public void unregister(Object o) {
+        }
+
+        @Override
+        public void unregisterAll() {
+        }
+    }
+
+    private static class RestClientApplicationProperties implements ApplicationProperties {
+
+        private final String baseUrl;
+
+        private RestClientApplicationProperties(URI jiraURI) {
+            this.baseUrl = jiraURI.getPath();
+        }
+
+        @Override
+        public String getBaseUrl() {
+            return baseUrl;
+        }
+
+        @Nonnull
+        @Override
+        public String getBaseUrl(UrlMode urlMode) {
+            return baseUrl;
+        }
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "Jamira Jira Client";
+        }
+
+        @Nonnull
+        @Override
+        public String getPlatformId() {
+            return ApplicationProperties.PLATFORM_JIRA;
+        }
+
+        @Nonnull
+        @Override
+        public String getVersion() {
+            return "unknown";
+        }
+
+        @Nonnull
+        @Override
+        public Date getBuildDate() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Nonnull
+        @Override
+        public String getBuildNumber() {
+            return String.valueOf(0);
+        }
+
+        @Override
+        public File getHomeDirectory() {
+            return new File(".");
+        }
+
+        @Override
+        public String getPropertyValue(final String s) {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+    }
+}

--- a/jamira-cli/src/main/java/org/tomitribe/jamira/cli/http/CustomAsynchronousJiraRestClientFactory.java
+++ b/jamira-cli/src/main/java/org/tomitribe/jamira/cli/http/CustomAsynchronousJiraRestClientFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Tomitribe and community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.jamira.cli.http;
+
+import com.atlassian.httpclient.api.factory.HttpClientOptions;
+import com.atlassian.jira.rest.client.api.AuthenticationHandler;
+import com.atlassian.jira.rest.client.api.JiraRestClient;
+import com.atlassian.jira.rest.client.auth.BasicHttpAuthenticationHandler;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousHttpClientFactory;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClient;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
+import com.atlassian.jira.rest.client.internal.async.DisposableHttpClient;
+
+import java.net.URI;
+
+/*
+ * Allows the specification of custom http client options.
+ */
+public class CustomAsynchronousJiraRestClientFactory extends AsynchronousJiraRestClientFactory {
+
+    public JiraRestClient create(final URI serverURI, final AuthenticationHandler authenticationHandler, final HttpClientOptions clientOptions) {
+        DisposableHttpClient httpClient = (new AsynchronousHttpClientFactory()).createClient(serverURI, authenticationHandler);
+        return new AsynchronousJiraRestClient(serverURI, httpClient);
+    }
+
+    public JiraRestClient createWithBasicHttpAuthentication(URI serverUri, String username, String password, HttpClientOptions clientOptions) {
+        return this.create(serverUri, new BasicHttpAuthenticationHandler(username, password), clientOptions);
+    }
+
+    public JiraRestClient createWithAuthenticationHandler(URI serverUri, AuthenticationHandler authenticationHandler, HttpClientOptions clientOptions) {
+        return this.create(serverUri, authenticationHandler, clientOptions);
+    }
+}


### PR DESCRIPTION
# What does this PR do?

Atlassian has hard-coded a 20 second socket timeout in their `HttpClientOptions` and do not allow the user to specify / modify them during the creatioin of the REST client.

This PR override sthe default SocketTimeOut with 60 minutes to allow bulk processing to complete without a SocketTimeoutException by making the client factory configurable (allow custom http client options)